### PR TITLE
docs(): Fix typo namepsace -> namespace

### DIFF
--- a/docs/api/rest.mdx
+++ b/docs/api/rest.mdx
@@ -3,7 +3,7 @@ title: rest
 order: 53
 ---
 
-The `rest` namepsace contains a set of [Request handlers](/docs/basics/request-handler) designed for convenient mocking of REST API requests.
+The `rest` namespace contains a set of [Request handlers](/docs/basics/request-handler) designed for convenient mocking of REST API requests.
 
 ## Methods
 


### PR DESCRIPTION
small typo in the rest docs page

thanks!